### PR TITLE
combine ideas

### DIFF
--- a/cryptoeconomics/bee-honey-pollen-0.0.1.md
+++ b/cryptoeconomics/bee-honey-pollen-0.0.1.md
@@ -4,14 +4,24 @@
     ! is a problem
 
 ### BEE = membership
-- only bees can vote in the hive
-- voting includes allowing new bees into the hive, removing bees from the hive, or moving funds from the hive community vault
-- ! No Check and Balances: some actions require consent from multiple stakeholder groups. This could look like allowing multiple parties to create proposals and vote, or by having independent votes but then requiring both votes to pass to take an action
-- ! Poor Cryptoeconomic Alignment: it is assumed that BEEs would be incentivized to make decisions that create value for the hive, and thus encourage more people to buy POLLEN, and thus creating more work/value for BEEs. This is not a direct incentive model though and is more of a long-term view. Politics, personal goals, and short term outlooks could totally mess that up lol. Maybe better to have a multiple stakeholder system, but where BEE votes are weighted more heavily than those outside the hive.
+- only bees can earn honey
+- anyone can become a bee by contributing
+1. funds 
+and/or
+2. work
+
+by
+
+1. buying pollen
+and/or
+2. PR/forking/creating any project and working on it
+- this saves time wasted on adding/removing bees from the hive, allows honey to solve the problem of allocating funds from the hive community vault, and resolves the issues of No Check and Balances and Poor Cryptoeconomic Alignment
 
 ### HONEY = reputation
 - only bees can earn honey
-- honey increases the voting power of bees
+- HONEY determines how POLLEN is allocated from the hive community vault to a given bee :
+
+(bee's honey)/(hive's honey) = (bee's pollen)/(hive community vault's pollen)
 
 ### POLLEN = signaling/rewards
 - anyone can purchase pollen against a bonding curve
@@ -22,6 +32,14 @@
 
 ### Bonding Curve
 - ETH <=> POLLEN
-- at a regular interval (voted on by bees), ETH is moved from the curve into the hive community vault
-- if bees want to fund/support/incentivize projects for the hive, they can vote to move ETH from the hive community vault back into the curve to get POLLEN, and then they can stake that POLLEN to the project they want to support
-- ? from a technical perspective, is it realistic to have a contract handle Vault => Curve => Bounty? And/or would we want an "admin" (Queen) to manage that process on behalf of the hive until we build a contract/function that does it automagically? 
+- whenever an investor buys POLLEN, a portion of their ETH is required to go to the hive community vault
+- if bees want to fund/support/incentivize projects for the hive, they directly stake POLLEN earned/allocated to the project they want to support
+- it is realistic to have a contract automagically handle Vault => Curve => Bounty according to the function
+
+(bee's honey)/(hive's honey) = (bee's pollen)/(hive community vault's pollen)
+
+as part of a meritocratic system based on projects:
+
+https://github.com/disclosure-exchange/whitepaper/wiki/R&D#merit-system
+
+- ? The tricky part is: How is honey measured/earned? Perhaps it should be decided by something in between admin/collective, sourcecred.io /automagic. What about conviction voting/auction?

--- a/cryptoeconomics/bee-honey-pollen-0.0.1.md
+++ b/cryptoeconomics/bee-honey-pollen-0.0.1.md
@@ -39,7 +39,7 @@ and/or
 and
 2. community vault
 
-with the funds split in a p:1−p ratio of reserve:community funding set by the hive (for example, .1:.9 is fitting for an early-stage startup, while .5:.5 would be fitting for an established startup)."
+with the funds split in a p:1−p ratio of reserve:community funding set by the hive (for example, .1:.9 is fitting for an early-stage startup, while .5:.5 would be fitting for an established startup).
 - the bonding curve mathematics are described here: https://hackmd.io/@themathematicianisin/BkikbN2kr
 - if bees want to fund/support/incentivize projects for the hive, they directly stake POLLEN earned/allocated to the project they want to support
 - it is realistic to have a contract automagically handle Vault => Curve => Bounty according to the function

--- a/cryptoeconomics/bee-honey-pollen-0.0.1.md
+++ b/cryptoeconomics/bee-honey-pollen-0.0.1.md
@@ -4,7 +4,6 @@
     ! is a problem
 
 ### BEE = membership
-- only bees can earn honey
 - anyone can become a bee by contributing
 1. funds 
 and/or
@@ -15,39 +14,36 @@ by
 1. buying pollen
 and/or
 2. PR/forking/creating any project and working on it
-- this saves time wasted on adding/removing bees from the hive, allows honey to solve the problem of allocating funds from the hive community vault, and resolves the issues of No Check and Balances and Poor Cryptoeconomic Alignment
+- this saves time wasted on adding/removing bees from the hive, allows honey to solve the problem of allocating funds from the hive community vault, and resolves the previously described issues of "No checks and balances" and "Poor cryptoeconomic alignment"
 
-### HONEY = reputation
-- only bees can earn honey
-- HONEY determines how POLLEN is allocated from the hive community vault to a given bee :
+### HONEY = signaling/allocations
+- only workers can earn honey
+- incoming hive community funds are converted to HONEY
+- bees use HONEY to determine how incoming HONEY/POLLEN is allocated from the hive community vault/stakes to bees, by signaling HONEY (support) for projects/subprojects/.../milestones/tasks/subtasks/contributors:
 
-(bee's honey)/(hive's honey) = (bee's pollen)/(hive community vault's pollen)
+(incoming HONEY received by subproject)/(total incoming HONEY to project) = (HONEY supporting subproject)/(total HONEY supporting subprojects)
+
+- for each organization/project a bee is a direct contributor of (their wallet either earns funds from or pays funds to), they choose how the HONEY in their wallet is signaled among the subprojects
 
 ### POLLEN = signaling/rewards
 - anyone can purchase pollen against a bonding curve
-- anyone can stake pollen to issues/requests
-- if bees earn pollen they can exchange it against the curve for the underlying asset, 
-- bees can also allocate POLLEN to whatever tasks they please just like anyone else. For example: if a bee is working on a project, but wants help with the UI because they don't like CSS/JS/whatever then they can stake POLLEN to that task just like anyone else
-- bees can also burn POLLEN for HONEY, but HONEY cannot be burned. This is a one-way function. When a bee burns POLLEN for HONEY they are trading immediate financial rewards from the curve for increased influence (voting weight) in the hive. This also increases the value of outstanding POLLEN, creating more rewards for other bees. It's a win/win (I think, research tbd).   
-
+- bees can exchange POLLEN against the curve for the underlying asset
+- bees can stake POLLEN to projects/subprojects/.../milestones/tasks/subtasks/issues/requests. For example: if a bee is working on a project, but wants help with the UI because they don't like CSS/JS/whatever then they can stake POLLEN to that task just like anyone else
+  
 ### Bonding Curve
 - This is a way to create an economically self-sustaining hive, by rewarding contributors with:
-1. POLLEN whose value is tied to a good/service, in return for ETH <=> POLLEN purchase
-2. the development of said good/service, in return for funding of projects.
-- Anyone can contribute at any time, either as an investor or BEE. Investors contribute funds to the hive’s
+1. POLLEN whose value is tied to a good/service, in return for underlying asset <--> POLLEN purchase
+2. the development of said good/service, in return for funding the hive community vault.
+- Anyone can contribute at any time by contributing funds to the hive’s
 1. bonding curve reserve
 and
 2. community vault
 
-with the funds split in a p:1−p ratio of reserve:community funding set by the hive (for example, .1:.9 is fitting for an early-stage startup, while .5:.5 would be fitting for an established startup).
+with the funds split in a λ:1−λ ratio of reserve:community funding set by the hive (for example, .1:.9 is fitting for an early-stage startup, while .5:.5 would be fitting for an established startup).
 - the bonding curve mathematics are described here: https://hackmd.io/@themathematicianisin/BkikbN2kr
 - if bees want to fund/support/incentivize projects for the hive, they directly stake POLLEN earned/allocated to the project they want to support
 - it is realistic to have a contract automagically handle Vault => Curve => Bounty according to the function
 
-(bee's honey)/(hive's honey) = (bee's pollen)/(hive community vault's pollen)
+(incoming HONEY received by subproject)/(total incoming HONEY to project) = (HONEY supporting subproject)/(total HONEY supporting subprojects)
 
-as part of a meritocratic system based on projects:
-
-https://github.com/disclosure-exchange/whitepaper/wiki/R&D#merit-system
-
-- ? How is honey measured/earned? Perhaps it should be decided by something in between admin/collective, sourcecred.io /automagic. What about conviction voting/auction: https://hackmd.io/@themathematicianisin/Sk-hh3Zgr
+as part of an optimal resource allocation system based on meritocracy: https://hackmd.io/@themathematicianisin/SyLhKHCWS

--- a/cryptoeconomics/bee-honey-pollen-0.0.1.md
+++ b/cryptoeconomics/bee-honey-pollen-0.0.1.md
@@ -31,8 +31,14 @@ and/or
 - bees can also burn POLLEN for HONEY, but HONEY cannot be burned. This is a one-way function. When a bee burns POLLEN for HONEY they are trading immediate financial rewards from the curve for increased influence (voting weight) in the hive. This also increases the value of outstanding POLLEN, creating more rewards for other bees. It's a win/win (I think, research tbd).   
 
 ### Bonding Curve
-- ETH <=> POLLEN
-- whenever an investor buys POLLEN, a portion of their ETH is required to go to the hive community vault
+- This is a way to create an economically self-sustaining hive, by rewarding contributors with:
+1. POLLEN whose value is tied to a good/service, in return for ETH <=> POLLEN purchase
+2. the development of said good/service, in return for funding of projects.
+- Anyone can contribute at any time, either as an investor or BEE. Investors contribute funds to the hive’s
+1. bonding curve reserve
+and
+2. community vault
+with the funds split in a p:1−p ratio of reserve:community funding set by the hive (for example, .1:.9 is fitting for an early-stage startup, while .5:.5 would be fitting for an established startup)."
 - if bees want to fund/support/incentivize projects for the hive, they directly stake POLLEN earned/allocated to the project they want to support
 - it is realistic to have a contract automagically handle Vault => Curve => Bounty according to the function
 
@@ -42,4 +48,4 @@ as part of a meritocratic system based on projects:
 
 https://github.com/disclosure-exchange/whitepaper/wiki/R&D#merit-system
 
-- ? The tricky part is: How is honey measured/earned? Perhaps it should be decided by something in between admin/collective, sourcecred.io /automagic. What about conviction voting/auction?
+- ? How is honey measured/earned? Perhaps it should be decided by something in between admin/collective, sourcecred.io /automagic. What about conviction voting/auction: https://hackmd.io/@themathematicianisin/Sk-hh3Zgr

--- a/cryptoeconomics/bee-honey-pollen-0.0.1.md
+++ b/cryptoeconomics/bee-honey-pollen-0.0.1.md
@@ -38,7 +38,9 @@ and/or
 1. bonding curve reserve
 and
 2. community vault
+
 with the funds split in a p:1−p ratio of reserve:community funding set by the hive (for example, .1:.9 is fitting for an early-stage startup, while .5:.5 would be fitting for an established startup)."
+- the bonding curve mathematics are described here: https://hackmd.io/@themathematicianisin/BkikbN2kr
 - if bees want to fund/support/incentivize projects for the hive, they directly stake POLLEN earned/allocated to the project they want to support
 - it is realistic to have a contract automagically handle Vault => Curve => Bounty according to the function
 

--- a/cryptoeconomics/bee-honey-pollen-0.0.1.md
+++ b/cryptoeconomics/bee-honey-pollen-0.0.1.md
@@ -4,7 +4,7 @@
     ! is a problem
 
 ### BEE = membership
-- anyone can become a bee by contributing
+- anyone can become a bee by providing
 1. funds 
 and/or
 2. work
@@ -16,19 +16,18 @@ and/or
 2. PR/forking/creating any project and working on it
 - this saves time wasted on adding/removing bees from the hive, allows honey to solve the problem of allocating funds from the hive community vault, and resolves the previously described issues of "No checks and balances" and "Poor cryptoeconomic alignment"
 
-### HONEY = signaling/allocations
-- only workers can earn honey
-- incoming hive community funds are converted to HONEY
-- bees use HONEY to determine how incoming HONEY/POLLEN is allocated from the hive community vault/stakes to bees, by signaling HONEY (support) for projects/subprojects/.../milestones/tasks/subtasks/contributors:
+### HONEY = reputation
+- only projects/subprojects/.../milestones/tasks/subtasks/workers can be signaled honey
+- bees use POLLEN to determine how incoming hive community funds are allocated to bees, by signaling HONEY (support) for projects/subprojects/.../milestones/tasks/subtasks/contributors:
 
-(incoming HONEY received by subproject)/(total incoming HONEY to project) = (HONEY supporting subproject)/(total HONEY supporting subprojects)
+(incoming funds received by subproject)/(total incoming funds to project) = (HONEY supporting subproject)/(total HONEY supporting subprojects)
 
-- for each organization/project a bee is a direct contributor of (their wallet either earns funds from or pays funds to), they choose how the HONEY in their wallet is signaled among the subprojects
+- for each organization/project a bee is a direct contributor of (their wallet either earns funds from or pays funds to), they choose how the POLLEN in their wallet is distributed among the subprojects (in the form of signal HONEY, not actually giving away POLLEN)
 
 ### POLLEN = signaling/rewards
 - anyone can purchase pollen against a bonding curve
 - bees can exchange POLLEN against the curve for the underlying asset
-- bees can stake POLLEN to projects/subprojects/.../milestones/tasks/subtasks/issues/requests. For example: if a bee is working on a project, but wants help with the UI because they don't like CSS/JS/whatever then they can stake POLLEN to that task just like anyone else
+- bees can distribute POLLEN to organizations/projects they're a direct contributor of as described above. For example: if a bee is working on a project, but wants help with the UI because they don't like CSS/JS/whatever then they can signal HONEY to that task just like anyone else
   
 ### Bonding Curve
 - This is a way to create an economically self-sustaining hive, by rewarding contributors with:
@@ -41,9 +40,9 @@ and
 
 with the funds split in a λ:1−λ ratio of reserve:community funding set by the hive (for example, .1:.9 is fitting for an early-stage startup, while .5:.5 would be fitting for an established startup).
 - the bonding curve mathematics are described here: https://hackmd.io/@themathematicianisin/BkikbN2kr
-- if bees want to fund/support/incentivize projects for the hive, they directly stake POLLEN earned/allocated to the project they want to support
+- if bees want to fund/support/incentivize projects for the hive, they directly signal POLLEN earned/allocated to the project they want to support
 - it is realistic to have a contract automagically handle Vault => Curve => Bounty according to the function
 
-(incoming HONEY received by subproject)/(total incoming HONEY to project) = (HONEY supporting subproject)/(total HONEY supporting subprojects)
+(incoming funds received by subproject)/(total incoming funds to project) = (HONEY supporting subproject)/(total HONEY supporting subprojects)
 
 as part of an optimal resource allocation system based on meritocracy: https://hackmd.io/@themathematicianisin/SyLhKHCWS


### PR DESCRIPTION
I agree with BEES/POLLEN/HONEY/community vault/curve (sounds much more user-friendly than workers/tokens/merit/project fund/augmented token bonding curve as described in https://github.com/disclosure-exchange/whitepaper/wiki/R&D), can we combine the two?

This is what my commits look like (a now complete DAO structure): https://github.com/DISC30/ideas/blob/patch-1/cryptoeconomics/bee-honey-pollen-0.0.1.md